### PR TITLE
Fix test workflow condition to run on pull requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
-    if: ${{ github.event.head_commit && !contains(github.event.head_commit.message, '[skip ci]') }}
+    if: ${{ !contains(github.event_name == 'pull_request' && github.event.pull_request.title || github.event.head_commit.message || '', '[skip ci]') }}
     
     steps:
       - name: Checkout repository


### PR DESCRIPTION
What this PR fixes:
• The test workflow was configured to trigger on PRs but had a condition that prevented it from actually running
• The issue was `github.event.head_commit` only exists for push events, not pull request events
• Updated the condition to properly handle both push and pull request events
The change:
• Before: Condition always evaluated to false for PRs, skipping tests
• After: Properly checks PR titles for pull requests and commit messages for pushes, respecting ‘[skip ci]’ in both cases