### PR TITLE
Add max_resample option in Hill Estimator to avoid infinite loop

### DIFF
--- a/src/tailestim/estimators/hill.py
+++ b/src/tailestim/estimators/hill.py
@@ -31,8 +31,12 @@ class HillEstimator(BaseTailEstimator):
         Flag to switch on/off generation of AMSE diagnostic plots.
     base_seed: None | SeedSequence | BitGenerator | Generator | RandomState, default=None
         Base random seed for reproducibility of bootstrap.
+    max_resample : int, default=50
+        Maximum number of resampling attempts when the double-bootstrap
+        detects a false AMSE minimum (k2 > k1). Raises RuntimeError
+        if exceeded.
     """
-    
+
     def __init__(
         self,
         bootstrap: bool = True,
@@ -42,6 +46,7 @@ class HillEstimator(BaseTailEstimator):
         verbose: bool = False,
         diagn_plots: bool = False,
         base_seed: Union[None, SeedSequence, BitGenerator, Generator, RandomState] = None,
+        max_resample: int = 50,
         **kwargs
     ):
         super().__init__(bootstrap=bootstrap, base_seed=base_seed, **kwargs)
@@ -50,6 +55,7 @@ class HillEstimator(BaseTailEstimator):
         self.eps_stop = eps_stop
         self.verbose = verbose
         self.diagn_plots = diagn_plots
+        self.max_resample = max_resample
 
     def _estimate(self, ordered_data: np.ndarray) -> Tuple:
         """Estimate the tail index using the Hill estimator.
@@ -72,7 +78,8 @@ class HillEstimator(BaseTailEstimator):
             verbose=self.verbose,
             diagn_plots=self.diagn_plots,
             eps_stop=self.eps_stop,
-            base_seed=self.base_seed
+            base_seed=self.base_seed,
+            max_resample=self.max_resample
         )
 
     def get_params(self) -> Dict[str, Any]:
@@ -91,6 +98,7 @@ class HillEstimator(BaseTailEstimator):
             "eps_stop": self.eps_stop,
             "verbose": self.verbose,
             "diagn_plots": self.diagn_plots,
+            "max_resample": self.max_resample,
             **self.kwargs
         }
 

--- a/src/tailestim/estimators/tail_methods.py
+++ b/src/tailestim/estimators/tail_methods.py
@@ -3,6 +3,7 @@ import sys
 import logging
 logging.basicConfig(level=logging.WARNING)
 
+
 def add_uniform_noise(data_sequence, p = 1, base_seed = None):
     """
     Function to add uniform random noise to a given dataset.
@@ -177,7 +178,8 @@ def get_moments_estimates_3(ordered_data):
 
 def hill_dbs(ordered_data, t_bootstrap = 0.5,
             r_bootstrap = 500, eps_stop = 1.0,
-            verbose = False, diagn_plots = False, base_seed=None):
+            verbose = False, diagn_plots = False, base_seed=None,
+            max_resample = 50):
     """
         Function to perform double-bootstrap procedure for
         Hill estimator.
@@ -196,6 +198,9 @@ def hill_dbs(ordered_data, t_bootstrap = 0.5,
             diagn_plots:  flag to switch on/off generation of AMSE diagnostic
                           plots.
             base_seed:    base random seed for reproducibility of bootstrap (default is None).
+            max_resample: maximum number of resampling attempts when AMSE
+                          false minimum is detected (k2 > k1). Raises
+                          ConvergenceError if exceeded. Default is 50.
 
         Returns:
             k_star:     number of order statistics optimal for estimation
@@ -234,7 +239,14 @@ def hill_dbs(ordered_data, t_bootstrap = 0.5,
 
     base_rng = np.random.default_rng(seed=base_seed)  # Accept random seed for reproducibility. Default seed is None.
 
+    resample_count = 0
     while k2 == None:
+        if resample_count >= max_resample:
+            raise RuntimeError(
+                f"Hill double-bootstrap failed to converge after "
+                f"{max_resample} resampling attempts (k2 > k1 persisted). "
+                f"Consider increasing max_resample or adjusting bootstrap parameters."
+            )
         # first bootstrap with n1 sample size
         for i in range(r_bootstrap):
             bs1_seed = base_rng.integers(0, 1_000_000)
@@ -277,7 +289,8 @@ def hill_dbs(ordered_data, t_bootstrap = 0.5,
             x2_arr = np.linspace(1./n2, 1.0, n2)
 
         if k2 > k1:
-            logging.warning("Warning (Hill): k2 > k1, AMSE false minimum suspected, resampling...")
+            resample_count += 1
+            logging.warning("Warning (Hill): k2 > k1, AMSE false minimum suspected, resampling... (attempt %d/%d)", resample_count, max_resample)
             # move left AMSE boundary to avoid numerical issues
             min_index1 = min_index1 + int(0.005*n)
             min_index2 = min_index2 + int(0.005*n)
@@ -318,7 +331,8 @@ def hill_dbs(ordered_data, t_bootstrap = 0.5,
 def hill_estimator(ordered_data,
                    bootstrap = True, t_bootstrap = 0.5,
                    r_bootstrap = 500, verbose = False,
-                   diagn_plots = False, eps_stop = 0.99, base_seed = None):
+                   diagn_plots = False, eps_stop = 0.99, base_seed = None,
+                   max_resample = 50):
     """
     Function to calculate Hill estimator for a given dataset.
     If bootstrap flag is True, double-bootstrap procedure
@@ -340,6 +354,8 @@ def hill_estimator(ordered_data,
         diagn_plots:  flag to switch on/off generation of AMSE diagnostic
                       plots.
         base_seed:    base random seed for reproducibility of bootstrap (default is None).
+        max_resample: maximum number of resampling attempts for the double-bootstrap
+                      procedure. Raises RuntimeError if exceeded. Default is 50.
 
     Returns:
         results: list containing an array of order statistics,
@@ -361,20 +377,22 @@ def hill_estimator(ordered_data,
         results = hill_dbs(ordered_data,
                            t_bootstrap = t_bootstrap,
                            r_bootstrap = r_bootstrap,
-                           verbose = verbose, 
+                           verbose = verbose,
                            diagn_plots = diagn_plots,
                            eps_stop = eps_stop,
-                           base_seed = base_seed)
+                           base_seed = base_seed,
+                           max_resample = max_resample)
         k_star, x1_arr, n1_amse, k1, max_index1, x2_arr, n2_amse, k2, max_index2 = results
         while k_star == None:
             logging.debug("Resampling...")
             results = hill_dbs(ordered_data,
                            t_bootstrap = t_bootstrap,
                            r_bootstrap = r_bootstrap,
-                           verbose = verbose, 
+                           verbose = verbose,
                            diagn_plots = diagn_plots,
                            eps_stop = eps_stop,
-                           base_seed = base_seed)
+                           base_seed = base_seed,
+                           max_resample = max_resample)
             k_star, x1_arr, n1_amse, k1, max_index1, x2_arr, n2_amse, k2, max_index2 = results
         xi_star = xi_arr[k_star-1]
         logging.info("Adjusted Hill estimated gamma:", 1 + 1./xi_star)

--- a/tests/test_tail_methods.py
+++ b/tests/test_tail_methods.py
@@ -102,6 +102,23 @@ def test_hill_estimator():
     assert all(x == bs1_results[0] for x in bs1_results), "Bootstrap results with same seed should be identical"
     assert all(x == bs2_results[0] for x in bs2_results), "Second bootstrap results with same seed should be identical"
 
+def test_hill_estimator_max_resample():
+    """Test that HillEstimator raises RuntimeError when max_resample is exceeded."""
+    # Near-constant degree sequence (n=115).
+    # With n < 200, the boundary shift int(0.005*n) == 0, so k2 > k1
+    # persists indefinitely and max_resample is always hit.
+    data = np.array([
+        12,12,12,12,11,12,12,12,11,11,10,10,10,11,10,12,11,11,11,11,
+        11,11,11,11,10,11,10,11,9,11,11,11,11,10,11,11,8,11,11,11,
+        11,10,7,11,11,11,11,11,11,11,9,11,10,12,10,11,10,10,10,8,
+        11,11,11,9,11,11,11,12,11,11,11,10,11,11,11,10,11,11,11,11,
+        11,11,11,11,11,9,11,11,12,11,9,11,11,10,10,10,10,8,11,10,
+        11,10,10,10,12,10,11,10,10,11,11,11,10,10,11,
+    ], dtype=float)
+    estimator = HillEstimator(bootstrap=True, max_resample=3, base_seed=42)
+    with pytest.raises(RuntimeError, match="failed to converge after 3 resampling"):
+        estimator.fit(data)
+
 def test_smooth_hill_estimator():
     np.random.seed(42)
     data = np.random.pareto(2, 1000)


### PR DESCRIPTION
## Overview
- Fixed a bug where Hill Estimator gets infinite loop during resampling. #35 
- It was caused by `if k2 > k1` condition in `hill_dbs()`. For n<200, `int(0.005*n)` always floors to 0, which does not increment `min_index1` and `min_index2`. This results in `k1` and `k2` to be stuck causing the infinite loop.

```py
if k2 > k1:
    print("Warning (Hill): k2 > k1, AMSE false minimum suspected, resampling...")
    # move left AMSE boundary to avoid numerical issues
    min_index1 = min_index1 + int(0.005*n)
    min_index2 = min_index2 + int(0.005*n)
    k2 = None
```

## Changes
- Added `max_resample` option in Hill Estimator. If resampling count exceeds this, it raises `RuntimeError`.
```py
HillEstimator(bootstrap=True, max_resample=3)
```
- Added tests for `max_resample` with provided degree sequence.