### PR TITLE
Version 0.7.0

### DIFF
--- a/src/tailestim/__about__.py
+++ b/src/tailestim/__about__.py
@@ -6,4 +6,4 @@
 # To make a new release, use the GitHub Actions workflow (release.yml), instead of modifying the version values below directly.
 # Detailed documentation are available in DEVELOP.md.
 
-__version__ = "0.6.0"
+__version__ = "0.7.0"


### PR DESCRIPTION
## Changes

### Bug fix
- Added `max_resample` parameter to the Hill estimator to prevent infinite loops during double-bootstrap resampling. When the bootstrap detects a false AMSE minimum (`k2 > k1`), it now raises a `RuntimeError` after exceeding the maximum number of resampling attempts (default: 50). (#36)

### Development tooling
- Migrated project management from hatch to uv (#38)
- Added ruff as the linter and formatter, replacing previous tooling. Applied ruff fixes across the codebase and added RUF, NPY, C4 rule sets. (#39)
- Migrated CI from deprecated `set-output` GitHub Actions syntax

**Full Changelog**: https://github.com/mu373/tailestim/compare/v0.6.0...v0.7.0