### PR TITLE
Update outdated GitHub Actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,12 +63,10 @@ jobs:
 
       - name: Create GitHub Release
         id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: "v${{ github.event.inputs.version }}"
-          release_name: "v${{ github.event.inputs.version }}"
+          name: "v${{ github.event.inputs.version }}"
           body: |
             Automated release of version v${{ github.event.inputs.version }}.
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,9 +4,9 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Enter the version name to release (e.g., 1.0.0).'
+        description: "Enter the version name to release (e.g., 1.0.0)."
         required: true
-        default: '1.0.0'
+        default: "1.0.0"
 
 jobs:
   release:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Update version
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,8 @@ jobs:
 
       - name: Install uv
         uses: astral-sh/setup-uv@v7
+        with:
+          cache-suffix: py${{ matrix.python-version }}
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           path: tail-estimation
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,25 +2,25 @@ name: Test tailestim
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
-      - 'docs/**'
-      - '.github/workflows/release.yml'
-      - '.gitignore'
-      - '.readthedocs.yaml'
-      - 'DEVELOP.md'
-      - 'LICENSE.txt'
-      - 'README.md'
+      - "docs/**"
+      - ".github/workflows/release.yml"
+      - ".gitignore"
+      - ".readthedocs.yaml"
+      - "DEVELOP.md"
+      - "LICENSE.txt"
+      - "README.md"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths-ignore:
-      - 'docs/**'
-      - '.github/workflows/release.yml'
-      - '.gitignore'
-      - '.readthedocs.yaml'
-      - 'DEVELOP.md'
-      - 'LICENSE.txt'
-      - 'README.md'
+      - "docs/**"
+      - ".github/workflows/release.yml"
+      - ".gitignore"
+      - ".readthedocs.yaml"
+      - "DEVELOP.md"
+      - "LICENSE.txt"
+      - "README.md"
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,12 +34,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Checkout tailestimation as subdirectory
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: ${{ secrets.TAILESTIMATION_REPO }}
           token: ${{ secrets.TAILESTIMATION_PAT }}


### PR DESCRIPTION
## Overview
Updated/migrated outdated GitHub Actions. This resolves all warnings shown in GitHub Actions.

## Changes
- Update actions/checkout to v6
- Update astral-sh/setup-uv to v7
- Migrate actions/create-release to softprops/action-gh-release
- Set cache-suffix to Python version for uv. This fixes following warning:
```
Failed to save:
Unable to reserve cache with key setup-uv-2-x86_64-unknown-linux-gnu-ubuntu-24.04-3.12.3-pruned-32b163d48e582e67ad159fc8ac3b2f0fd2b4a003c03e76ab2472347d505f8d9d, another job may be creating this cache.
```
- Fix yaml formatting for GitHub Actions